### PR TITLE
Auto release version 1 when new changes land in main branch

### DIFF
--- a/.github/workflows/on_push.yml
+++ b/.github/workflows/on_push.yml
@@ -1,0 +1,26 @@
+name: Deploy new tag
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Use Node.js 16.x
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16.x
+      - run: npm ci
+      - run: npm run build --if-present
+      - name: Commit report
+        run: |
+          git config --global user.name 'karelhala'
+          git config --global user.email 'khala@redhat.com'
+          git commit --allow-empty -am "Releasing new version"
+          git tag -f -a -m "" v1
+          git push -f --tags


### PR DESCRIPTION
### Description

Since we don't want to build and tag whenever new change happens we should add auto releaser to this GH action. This PR will add new action that is triggered on push to main branch, builds it and pushes `v1` tag.