### PR TITLE
Add github actions trigger

### DIFF
--- a/lib/gh-bot.js
+++ b/lib/gh-bot.js
@@ -1,7 +1,29 @@
 const axios = require('axios');
 
-async function ghTrigger({ owner, repo, number }, releaseType, context, config) {
-  context.log('Missing implementation!');
+async function ghTrigger({ owner, repo }, config) {
+  const body = {
+    'event_type': config.event_type
+}
+
+const githubActionURL = ` https://api.github.com/repos/${(config?.group) || owner}/${(config?.repo) || repo}/dispatches`;
+console.log(`Notifyig travis on URL: ${githubActionURL}`);
+console.log(`With data: ${JSON.stringify(body)}`);
+try {
+    axios.post(
+        githubActionURL,
+        body,
+        {
+            headers: {
+                'Authorization': `Bearer ${config?.token}`
+            }
+        }
+    ).catch(({ response: { data, status } }) => {
+        console.log('Error status: ', status);
+        console.log('Error data: ', data);
+    })
+} catch(e) {
+    console.log(e);
+}
 }
 
 module.exports = ghTrigger;

--- a/lib/gh-bot.js
+++ b/lib/gh-bot.js
@@ -6,7 +6,7 @@ async function ghTrigger({ owner, repo }, config) {
 }
 
 const githubActionURL = ` https://api.github.com/repos/${(config?.group) || owner}/${(config?.repo) || repo}/dispatches`;
-console.log(`Notifyig travis on URL: ${githubActionURL}`);
+console.log(`Notifyig Github on URL: ${githubActionURL}`);
 console.log(`With data: ${JSON.stringify(body)}`);
 try {
     axios.post(

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,8 +1,8 @@
 const core = require('@actions/core');
 const github = require('@actions/github');
-const travisTrigger = require('./travis-bot');
-const ghTrigger = require('./gh-bot');
-const createComment = require('./comment-bot');
+const travisTrigger = require('./lib/travis-bot');
+const ghTrigger = require('./lib/gh-bot');
+const createComment = require('./lib/comment-bot');
 
 const bug = 'bugfix';
 const minor = 'minor';
@@ -60,7 +60,7 @@ try {
 
   console.log('Can release?', allowedUsers.includes(triggeredBy));
 
-  if (merged) {
+  if (merged && releaseType) {
     console.log('PR has been merged!');
     createComment({ ...ghConfig, body: triggerRelease(releaseType) }, { botName: core.getInput('bot-name'), token: core.getInput('gh-bot-token') });
     if (isTravis) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,8 +1,8 @@
 const core = require('@actions/core');
 const github = require('@actions/github');
-const travisTrigger = require('./lib/travis-bot');
-const ghTrigger = require('./lib/gh-bot');
-const createComment = require('./lib/comment-bot');
+const travisTrigger = require('./travis-bot');
+const ghTrigger = require('./gh-bot');
+const createComment = require('./comment-bot');
 
 const bug = 'bugfix';
 const minor = 'minor';


### PR DESCRIPTION
### Description

Some apps can decide not to use travis build, but instead they can use github actions build. This PR adds such option by querying github API over on `dispatches`