### PR TITLE
Add safe guard to prevent accidental releases

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -18,6 +18,10 @@ const toReleaseType = ({ comment, pull_request }) => {
   const { body: type } = comment || {};
   const label = pull_request?.labels?.find((item) => Object.keys(releaseTypes).includes(item?.name))
   console.log(JSON.stringify(label), 'Found label');
+  if (label === 'released' || label?.name === 'released') {
+    console.log('PR contains released label, not releasing!');
+    return false;
+  }
   return {
     'bug': bug,
     'release': bug,
@@ -58,9 +62,10 @@ try {
 
   const triggeredBy = action?.comment?.user?.login || action?.sender.login;
 
-  console.log('Can release?', allowedUsers.includes(triggeredBy));
+  const canRelease = allowedUsers.includes(triggeredBy);
+  console.log('Can release?', canRelease);
 
-  if (merged && releaseType) {
+  if (merged && releaseType && canRelease) {
     console.log('PR has been merged!');
     createComment({ ...ghConfig, body: triggerRelease(releaseType) }, { botName: core.getInput('bot-name'), token: core.getInput('gh-bot-token') });
     if (isTravis) {


### PR DESCRIPTION
### Description

Add safe guards to prevent releases triggered by someone who doesn't have rights to release. And also check fo `released` label if present do not fire new release.